### PR TITLE
add configuration option for transient pop notification

### DIFF
--- a/ovos_PHAL_plugin_notification_widgets/__init__.py
+++ b/ovos_PHAL_plugin_notification_widgets/__init__.py
@@ -50,6 +50,7 @@ class OVOSNotificationWidgetsPlugin(PHALPlugin):
         """ Get Notification & Action """
         LOG.info("Notification API: Display Notification")
         notification_message = {
+            "duration": message.data.get("duration", 10),
             "sender": message.data.get("sender", ""),
             "text": message.data.get("text", ""),
             "action": message.data.get("action", ""),


### PR DESCRIPTION
Adds the possibility to define a on screen duration for transient pop notifications.
Simply adds a duration key to the `ovos.notification.api.set` event handler that defaults to 10 (seconds)

Positivly tested

Related: [Ovos-Shell](https://github.com/OpenVoiceOS/ovos-shell/pull/28) / [ovos-utils](https://github.com/OpenVoiceOS/ovos-utils/pull/92)

Closes: #3 